### PR TITLE
Add pre-commit hook with black 19.10b

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,6 @@
     name: black-nb
     entry: black-nb
     language: python
-    language_version: python3.8
+    language_version: python3
     files: '\.ipynb$'
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: black-nb
+    name: black-nb
+    entry: black-nb
+    language: python
+    language_version: python3.8
+    files: '\.ipynb$'
+

--- a/black_nb/cli.py
+++ b/black_nb/cli.py
@@ -141,7 +141,7 @@ def cli(
     """
     write_back = black.WriteBack.from_configuration(check=check, diff=False)
     mode = black.FileMode(
-        target_versions=set([black.TargetVersion.PY36]),
+        target_versions={black.TargetVersion.PY36},
         line_length=line_length,
         is_pyi=False,
         string_normalization=True,

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,7 @@ def flake8(session):
 @nox.session()
 def black(session):
     """Check code formatting with black."""
-    session.install("black==18.9b0")
+    session.install("black==19.10b0")
     if session.posargs:
         session.run("black", *session.posargs)
     else:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     setup_requires=["setuptools_scm"],
     python_requires='>3.6',
     install_requires=[
-        "attrs>=18.2.0", "black==18.9b0", "click>=7.0", "nbformat>=4.4.0"
+        "attrs>=18.2.0", "black>=19.10b0", "click>=7.0", "nbformat>=4.4.0"
     ],
     entry_points={"console_scripts": ["black-nb=black_nb.cli:cli"]},
 )


### PR DESCRIPTION
Implements fixes to breaking changes in black 19.x release. black-nb is now again compatible with the latest black release.

This enables the use of pre-commit hooks in combination with black pre-commit hooks with the same version of black. If your project contains both ipynb and regular python files, this ensures you have the same code standard for all python code.

Fixes issues #35 and #34 