### PR TITLE
Fix bug with trailing semicolon for comment lines and add tests

### DIFF
--- a/black_nb/cli.py
+++ b/black_nb/cli.py
@@ -334,12 +334,22 @@ def format_cell_source(
 def format_str(
     src_contents: str, *, mode: black.FileMode = black.FileMode(),
 ) -> black.FileContent:
+
+    # Strip trailing semicolon because Black removes it, but it is an
+    # important feature in notebooks.
+    # Only a single trailing semicolon is supported. If the cell contains
+    # multiple trailing semicolons black_nb will fail.
     trailing_semi_colon = src_contents.rstrip()[-1] == ";"
+
     src_contents = hide_magic(src_contents)
     dst_contents = black.format_str(src_contents, mode=mode)
     dst_contents = dst_contents.rstrip()
-    if trailing_semi_colon:
+
+    # Replace the missing semi colon, except when Black didn't remove it
+    # which happens if the last line is a comment
+    if trailing_semi_colon and dst_contents.rstrip()[-1] != ";":
         dst_contents = f"{dst_contents};"
+
     dst_contents = reveal_magic(dst_contents)
     return dst_contents
 

--- a/tests/data/formatting_tests/unformatted.ipynb
+++ b/tests/data/formatting_tests/unformatted.ipynb
@@ -8,8 +8,27 @@
    "source": [
     "badly_formatted_list=['1',2,'3',4]"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cell ending in comment with a semicolon;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cell ending in line with a semicolon\n",
+    "1+1;"
+   ]
   }
- ],
+],
  "metadata": {
   "kernelspec": {
    "display_name": "Python 3",

--- a/tests/test_black_nb.py
+++ b/tests/test_black_nb.py
@@ -21,6 +21,14 @@ def test_formatting(tmp_path):
     formatting = CliRunner().invoke(cli, [str(dst_dir)])
     assert formatting.exit_code == 0
 
+    with open(dst_dir / "unformatted.ipynb") as file:
+        formatted_str = file.read()
+
+        # check correct semicolon in code
+        assert "1 + 1;" in formatted_str
+        # check correct semicolon in comment
+        assert "# cell ending in comment with a semicolon;" in formatted_str
+
     formatted = CliRunner().invoke(cli, ["--check", str(dst_dir)])
     assert formatted.exit_code == 0
 


### PR DESCRIPTION
While trailing semicolons at the end of a cell were correctly accounted for by adding them back into the code after Black removed them; this failed if the last line of a cell was a comment. Black won't remove the trailing semicolon from a comment line, but black-nb does append it. This results in a double semicolon and an error.

Thus I propose to add some logic which prevents the addition of a semicolon at the end of a line if it is already there. This works for most reasonable cases.

I have added two test cases: a cell ending in line of code with a semicolon, and a cell ending in a comment with a semicolon.

I believe this closes one item on the list in issue #9.