### PR TITLE
Update README  to say default line length is 88

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Usage: black-nb [OPTIONS] [SRC]...
 
 Options:
   -l, --line-length INTEGER  How many characters per line to allow.  [default:
-                             79]
+                             88]
   --check                    Don't write the files back, just return the
                              status.  Return code 0 means nothing would
                              change.  Return code 1 means some files would be


### PR DESCRIPTION
README says the default is 79 while the code uses black's default which is 88.

Relevant code snippet

https://github.com/tomcatling/black-nb/blob/f6f62237cea8bf63a0a5c49504ba6c672d64c368/black_nb/cli.py#L26

Might want to merge this right before the next release to not confuse people as the latest version of the package still uses 79 as default 