### PR TITLE
Comments with trailing question marks interpreted as magic

### DIFF
--- a/black_nb/cli.py
+++ b/black_nb/cli.py
@@ -284,7 +284,10 @@ def format_file_in_place(
     If `write_back` is YES, write reformatted code to the file.
     """
     try:
-        src_contents = nbformat.read(str(src), as_version=nbformat.NO_CONVERT,)
+        src_contents = nbformat.read(
+            str(src),
+            as_version=nbformat.NO_CONVERT,
+        )
     except nbformat.reader.NotJSONError:
         raise black.InvalidInput("Not JSON")
     except AttributeError:
@@ -352,7 +355,9 @@ def format_cell_source(
 
 
 def format_str(
-    src_contents: str, *, mode: black.FileMode = black.FileMode(),
+    src_contents: str,
+    *,
+    mode: black.FileMode = black.FileMode(),
 ) -> black.FileContent:
 
     # Strip trailing semicolon because Black removes it, but it is an
@@ -378,7 +383,10 @@ def assert_equivalent(src: str, dst: str) -> None:
     black.assert_equivalent(hide_magic(src), hide_magic(dst))
 
 
-def assert_stable(dst: str, mode: black.FileMode = black.FileMode(),) -> None:
+def assert_stable(
+    dst: str,
+    mode: black.FileMode = black.FileMode(),
+) -> None:
     new_dst = format_str(dst, mode=mode)
     if dst != new_dst:
         raise AssertionError(
@@ -391,7 +399,11 @@ def contains_magic(line: str) -> bool:
     if len(line) == 0:
         return False
     else:
-        return line[0] == "%" or line[0] == "!" or line[-1] == "?"
+        return (
+            line[0] == "%"
+            or line[0] == "!"
+            or (line[-1] == "?" and line.lstrip()[0] != "#")
+        )
 
 
 def hide_magic(source: str) -> str:

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,7 @@ def flake8(session):
 @nox.session()
 def black(session):
     """Check code formatting with black."""
-    session.install("black==19.10b0")
+    session.install("black==21.4b0")
     if session.posargs:
         session.run("black", *session.posargs)
     else:

--- a/tests/data/formatting_tests/unformatted.ipynb
+++ b/tests/data/formatting_tests/unformatted.ipynb
@@ -37,6 +37,19 @@
     "#cell containing `?` IPython syntax\n",
     "sum?"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    #indented comment ending in a ?\n",
+    "    pass\n",
+    "finally:\n",
+    "    pass"
+   ]
   }
  ],
  "metadata": {
@@ -55,9 +68,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This fixes #63 
The relevant bit is
`(line[-1] == "?" and line.lstrip()[0] != "#")`
We ignore 'magic lines' that start with a comment.
There is a new test cell in unformatted.ipynb which failed before the fix and passes after the fix

I also updated the black version in noxfile.py so it is the same as in setup.py (as per #61). This caused some cosmetic changes in cli.py. 